### PR TITLE
Add boolean distinction for tiny types:

### DIFF
--- a/src/test-helpers/testHelpers.ts
+++ b/src/test-helpers/testHelpers.ts
@@ -46,6 +46,7 @@ export function makeEmptyTypeSpec(): TypeSpec {
     target: undefined,
     properties: undefined,
     hasAdditionalProperties: false,
-    additionalPropertiesType: undefined
+    additionalPropertiesType: undefined,
+    isTinyType: false
   };
 }

--- a/src/typespec.ts
+++ b/src/typespec.ts
@@ -18,6 +18,7 @@ export interface TypeSpec {
   readonly hasAdditionalProperties: boolean;
   readonly additionalPropertiesType: TypeSpec | undefined;
   readonly crl8QualifiedClassname?: string;
+  readonly isTinyType: boolean;
 }
 
 export function makeTypeSpecFromSwaggerType(
@@ -38,6 +39,7 @@ export function makeTypeSpecFromSwaggerType(
     properties: undefined,
     hasAdditionalProperties: false,
     additionalPropertiesType: undefined,
-    crl8QualifiedClassname: swaggerType["x-qualified-classname"]
+    crl8QualifiedClassname: swaggerType["x-qualified-classname"],
+    isTinyType: !!swaggerType["x-qualified-classname"]
   };
 }


### PR DESCRIPTION
Couldn't get mustache templates to recognize `#crl8QualifiedClassname` as a truthy value. Added an explicit boolean value and re-ran with `yarn link` on the most recent web-gateway.

[Relevant Gist](https://gist.github.com/JSimoni42/e0cd551829893e3cf8e7772b572c442b)
